### PR TITLE
feat: add document/file forwarding support

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -104,6 +104,7 @@ async def send_photo(update: MessageUpdate, user: User) -> None:
 
 @reply
 async def send_document(update: MessageUpdate, user: User) -> None:
+    assert update.message.document is not None
     file = await update.message.document.get_file()
     document = await download(file)
     filename = update.message.document.file_name or Path(file.file_path).name  # type: ignore[arg-type]

--- a/src/bot.py
+++ b/src/bot.py
@@ -103,6 +103,35 @@ async def send_photo(update: MessageUpdate, user: User) -> None:
 
 
 @reply
+async def send_document(update: MessageUpdate, user: User) -> None:
+    file = await update.message.document.get_file()
+    document = await download(file)
+    filename = update.message.document.file_name or Path(file.file_path).name  # type: ignore[arg-type]
+    subject = f"File: {filename}"
+    text = " "
+
+    if update.message.caption is not None:
+        text = update.message.caption.strip()
+        if text:
+            subject = f"File: {get_subject(text)}"
+
+    tasks.send_file.apply_async(
+        kwargs={
+            "user_id": user.pk,
+            "file": document,
+            "filename": filename,
+            "subject": subject,
+            "text": text,
+        },
+        link=tasks.react.si(
+            chat_id=update.message.chat_id,
+            message_id=update.message.message_id,
+            reaction="👌",
+        ),
+    )
+
+
+@reply
 async def prompt_for_setting_email(update: TextMessageUpdate) -> None:
     await update.message.reply_text(text=render("please_send_email"))
 
@@ -173,6 +202,7 @@ def bot_app() -> Application:
     application.add_handler(MessageHandler(~ConfirmedUserFilter(), prompt_for_confirm))
     application.add_handler(MessageHandler(ConfirmedUserFilter() & filters.TEXT, send_text_message))
     application.add_handler(MessageHandler(ConfirmedUserFilter() & filters.PHOTO, send_photo))
+    application.add_handler(MessageHandler(ConfirmedUserFilter() & filters.Document.ALL, send_document))
 
     return application
 

--- a/src/bot.py
+++ b/src/bot.py
@@ -14,7 +14,7 @@ from . import celery as tasks
 from .framework import reply
 from .helpers import download, enable_logging, get_subject, init_sentry
 from .models import User, create_tables, get_user_instance
-from .t import HumanMessage, MessageUpdate, TextMessageUpdate
+from .t import DocumentMessageUpdate, HumanMessage, MessageUpdate, TextMessageUpdate
 from .tpl import render
 
 load_dotenv()
@@ -103,8 +103,7 @@ async def send_photo(update: MessageUpdate, user: User) -> None:
 
 
 @reply
-async def send_document(update: MessageUpdate, user: User) -> None:
-    assert update.message.document is not None
+async def send_document(update: DocumentMessageUpdate, user: User) -> None:
     file = await update.message.document.get_file()
     document = await download(file)
     filename = update.message.document.file_name or Path(file.file_path).name  # type: ignore[arg-type]

--- a/src/t.py
+++ b/src/t.py
@@ -1,4 +1,4 @@
-from telegram import Message, PhotoSize, Update, User
+from telegram import Document, Message, PhotoSize, Update, User
 
 
 class HumanMessage(Message):
@@ -24,3 +24,12 @@ class PhotoMessage(HumanMessage):
 
 class FileMessageUpdate(MessageUpdate):
     message: PhotoMessage
+
+
+class DocumentMessage(HumanMessage):
+    document: Document
+    caption: str | None
+
+
+class DocumentMessageUpdate(MessageUpdate):
+    message: DocumentMessage


### PR DESCRIPTION
## What

Adds support for forwarding documents (PDF, DOCX, ZIP, and any other file type) sent to the bot as email attachments.

## Why

Users were unable to forward files to their inbox. Sending a PDF would result in it being silently ignored by the bot.

Closes #352

## How

Added a `send_document` handler in `bot.py` following the same pattern as the existing `send_photo` handler:

- Fetches the file via Telegram API
- Downloads it into memory
- Preserves the original filename from `message.document.file_name`
- Dispatches `send_file` Celery task (already supports arbitrary file attachments)
- Sends a 👌 reaction on success

Registered with `filters.Document.ALL` so it catches all document types, not just PDFs.

## Changes

- `src/bot.py` — new `send_document` handler + handler registration